### PR TITLE
Update service root nodes when importing Turku services

### DIFF
--- a/services/management/commands/turku_service_import/services.py
+++ b/services/management/commands/turku_service_import/services.py
@@ -4,6 +4,7 @@ import pytz
 from munigeo.importer.sync import ModelSyncher
 
 from services.management.commands.services_import.keyword import KeywordHandler
+from services.management.commands.services_import.services import update_service_root_service_nodes
 from services.management.commands.turku_service_import.utils import get_turku_resource, set_syncher_object_field, \
     set_syncher_tku_translated_field
 from services.models import ServiceNode, Service
@@ -139,4 +140,5 @@ class ServiceImporter:
 
 def import_services(**kwargs):
     service_importer = ServiceImporter(**kwargs)
-    return service_importer.import_services()
+    service_importer.import_services()
+    update_service_root_service_nodes()


### PR DESCRIPTION
If `root_service_nodes` are not updated their value will be null, which will cause at least the detail view’s service nodes’ colours not working.

Null values will default to green:
![null_nodes](https://user-images.githubusercontent.com/10584178/53242074-64819700-36ac-11e9-8f86-8efe8028198b.png)


Correct should have the same colour as their root_service_node:
![correct](https://user-images.githubusercontent.com/10584178/53242082-69464b00-36ac-11e9-8709-cd7c3165cfd5.png)
