### PR TITLE
Don’t return fallback language option

### DIFF
--- a/services/management/commands/turku_service_import/units.py
+++ b/services/management/commands/turku_service_import/units.py
@@ -13,7 +13,7 @@ from munigeo.models import Municipality
 from services.management.commands.services_import.services import update_service_node_counts
 from services.management.commands.turku_service_import.utils import (
     get_turku_resource, nl2br, set_syncher_object_field, set_syncher_tku_translated_field,
-    get_weekday_str, get_localized_value_with_fallback)
+    get_weekday_str, get_localized_value)
 from services.management.commands.utils.text import clean_text
 from services.models import Service, ServiceNode, Unit, UnitServiceDetails, UnitIdentifier, UnitConnection
 
@@ -370,8 +370,8 @@ class UnitImporter:
             }
             names = {
                 'name_{}'.format(language):
-                    get_localized_value_with_fallback(descriptions, language) or  # NOQA
-                    get_localized_value_with_fallback(type_names, language)
+                    get_localized_value(descriptions, language) or  # NOQA
+                    get_localized_value(type_names, language)
                 for language in LANGUAGES
             }
 
@@ -397,7 +397,7 @@ class UnitImporter:
         names = defaultdict(str)
 
         for language in LANGUAGES:
-            names[language] = get_localized_value_with_fallback(opening_hours_datum.get('kuvaus_kieliversiot', {}), language)  # NOQA
+            names[language] = get_localized_value(opening_hours_datum.get('kuvaus_kieliversiot', {}), language)  # NOQA
 
         for language in LANGUAGES:
             if not names[language]:

--- a/services/management/commands/turku_service_import/utils.py
+++ b/services/management/commands/turku_service_import/utils.py
@@ -144,11 +144,6 @@ def get_weekday_str(index, lang='fi'):
     return weekdays[index - 1][['fi', 'sv', 'en'].index(lang)]
 
 
-def get_localized_value_with_fallback(data, preferred_language='fi'):
+def get_localized_value(data, preferred_language='fi'):
     assert preferred_language in ('fi', 'sv', 'en')
-    if preferred_language == 'fi':
-        return data.get('fi') or data.get('en') or data.get('sv') or ''
-    elif preferred_language == 'sv':
-        return data.get('sv') or data.get('fi') or data.get('en') or ''
-    else:
-        return data.get('en') or data.get('fi') or data.get('sv') or ''
+    return data.get(preferred_language) or ''


### PR DESCRIPTION
It was decided that in case of missing translations it is better to have an empty value than in the wrong language.