### PR TITLE
Add api/ prefix to API URLs

### DIFF
--- a/smbackend/urls.py
+++ b/smbackend/urls.py
@@ -35,8 +35,8 @@ urlpatterns = [
     # url(r'^admin/', include(admin.site.urls)),
 
     url(r'^open311/', views.post_service_request, name='services'),
-    url(r'^v2/', include(router.urls)),
-    url(r'^v2/api-token-auth/', obtain_auth_token, name='api-auth-token'),
-    url(r'^v2/redirect/unit/', UnitRedirectViewSet.as_view({'get': 'list'})),
+    url(r'^api/v2/', include(router.urls)),
+    url(r'^api/v2/api-token-auth/', obtain_auth_token, name='api-auth-token'),
+    url(r'^api/v2/redirect/unit/', UnitRedirectViewSet.as_view({'get': 'list'})),
     url(r'', include(shortcutter_urls)),
 ]


### PR DESCRIPTION
This is a fix for solving pagination links in the API.

Note that this is breaking upstream merging capabilities with the Helsinki setup as they do not have such prefix in their codebase. The reason for this is that they are using uwsgi+kong to handle such URL prefixing, something that would currently take too long for us to solve.
In the future, if this code is to be merge, solving this issue in another way would be recommended.